### PR TITLE
Adds code to read the form flow lib's messages properties file

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,6 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.flywaydb:flyway-core'
 	implementation fileTree(dir: "$rootDir/../form-flow/lib/build/libs", include: '*.jar')
-	implementation fileTree(dir: "$rootDir/../form-flow/lib/build/resources")
 
 	compileOnly 'org.projectlombok:lombok'
 	compileOnly 'org.springframework.boot:spring-boot-starter-actuator'

--- a/src/main/java/org/formflowstartertemplate/app/config/LocaleConfiguration.java
+++ b/src/main/java/org/formflowstartertemplate/app/config/LocaleConfiguration.java
@@ -33,21 +33,4 @@ public class LocaleConfiguration implements WebMvcConfigurer {
 	public void addInterceptors(InterceptorRegistry registry) {
 		registry.addInterceptor(localeChangeInterceptor());
 	}
-
-	@Bean
-	public ResourceBundleMessageSource messageSource() {
-		ResourceBundleMessageSource messageSource = new ResourceBundleMessageSource();
-		// setBasenames() will do three things:
-		// 1) It will override any previous setting of basenames. Only these names/paths exist now.
-		// 2) It will look for messages in sequential order and if something is found in a file, it stops looking there.
-		//    Order matters and if you want to provide overrides, make sure they are in the earlier
-		//    files (like 'messages', rather than 'messages-form-flow').
-		// 3) For i18n this will look for files with the basename + "_[lang]", like messages_en.properties,
-		//    automatically for you.
-		//
-		messageSource.setBasenames("messages", "messages-form-flow");
-		messageSource.setDefaultEncoding("UTF-8");
-
-		return messageSource;
-	}
 }

--- a/src/main/java/org/formflowstartertemplate/app/config/LocaleConfiguration.java
+++ b/src/main/java/org/formflowstartertemplate/app/config/LocaleConfiguration.java
@@ -37,8 +37,17 @@ public class LocaleConfiguration implements WebMvcConfigurer {
 	@Bean
 	public ResourceBundleMessageSource messageSource() {
 		ResourceBundleMessageSource messageSource = new ResourceBundleMessageSource();
-		messageSource.setBasename("messages");
+		// setBasenames() will do three things:
+		// 1) It will override any previous setting of basenames. Only these names/paths exist now.
+		// 2) It will look for messages in sequential order and if something is found in a file, it stops looking there.
+		//    Order matters and if you want to provide overrides, make sure they are in the earlier
+		//    files (like 'messages', rather than 'messages-form-flow').
+		// 3) For i18n this will look for files with the basename + "_[lang]", like messages_en.properties,
+		//    automatically for you.
+		//
+		messageSource.setBasenames("messages", "messages-form-flow");
 		messageSource.setDefaultEncoding("UTF-8");
+
 		return messageSource;
 	}
 }

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -1,20 +1,3 @@
-general.month=Month
-general.day=Day
-general.year=Year
-general.edit=edit
-general.delete=delete
-general.inputs.yes=Yes
-general.inputs.no=No
-general.inputs.continue=Continue
-general.inputs.submit=Submit
-general.language.english=English
-general.language.spanish=Español
-general.me=Me
-general.you=You
-general.your=Your
-
-error.error=Error
-
 validations.make-sure-to-provide-a-first-name=Make sure to provide a first name.
 validations.test=This is just a test.
 


### PR DESCRIPTION
This tweaks the spot where we tell the system where the message property files are.  

The general messages have been pulled out and put into the form-flow lib's message properties file.   We may want to move more over, once we review the templates. 

related to https://github.com/codeforamerica/form-flow/pull/10