### PR TITLE
Swap spring profile from dev to demo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,4 +12,4 @@ RUN set -a  && \
     
 EXPOSE 8080
 
-ENTRYPOINT ["java", "-jar", "/opt/form-flow-starter-app/app.jar"]
+ENTRYPOINT ["java", "-jar", "/opt/form-flow-starter-app/app.jar", "--spring.profiles.active=demo"]

--- a/src/main/resources/application-demo.yaml
+++ b/src/main/resources/application-demo.yaml
@@ -1,0 +1,5 @@
+spring:
+  thymeleaf:
+    cache: true
+  datasource:
+    url: jdbc:postgresql://host.docker.internal:5432/starter-app

--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -1,3 +1,0 @@
-spring:
-  datasource:
-    url: jdbc:postgresql://localhost:5432/starter-app

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -13,7 +13,7 @@ spring:
       cache:
         period: 0
   datasource:
-    url: jdbc:postgresql://host.docker.internal:5432/starter-app
+    url: jdbc:postgresql://localhost:5432/starter-app
     username: starter-app
     password:
 management:


### PR DESCRIPTION
Make localhost assumption by default and use demo to point to docker db location.

Before:
- A person needs to add the `dev` profile when running locally (usually in IntelliJ)
- When we deploy to `docker`, we don't use `dev` so that it points to the `docker` db url

After this PR:
- It assumes to use `localhost` by default
- When we deploy to `docker`, we use `demo` to then point to the `docker` db url