### PR TITLE
Adds commit hash to index page's footer

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -62,7 +62,6 @@ dependencies {
         println "Using 0.0.1-SNAPSHOT 💜"
     }
 
-
     compileOnly 'org.projectlombok:lombok'
 
     developmentOnly 'org.springframework.boot:spring-boot-devtools'

--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,9 @@ plugins {
     id 'org.springframework.boot' version '2.7.3'
     id 'io.spring.dependency-management' version '1.0.13.RELEASE'
     id 'java'
+
+    // https://plugins.gradle.org/plugin/com.gorylenko.gradle-git-properties
+    id "com.gorylenko.gradle-git-properties" version "2.3.2"
 }
 
 configurations {
@@ -59,6 +62,7 @@ dependencies {
         println "Using 0.0.1-SNAPSHOT 💜"
     }
 
+
     compileOnly 'org.projectlombok:lombok'
 
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
@@ -74,6 +78,10 @@ dependencies {
     testImplementation 'com.h2database:h2'
 
     runtimeOnly 'org.postgresql:postgresql'
+}
+
+springBoot {
+    buildInfo()
 }
 
 tasks.named('test') {

--- a/src/main/java/org/formflowstartertemplate/app/StaticPageController.java
+++ b/src/main/java/org/formflowstartertemplate/app/StaticPageController.java
@@ -31,7 +31,7 @@ public class StaticPageController {
     // provide a model so that we can pass the git commit hash to the footer, via the index page.
     HashMap<String, Object> model = new HashMap<>();
     model.put("codeCommitHashShort", gitProperties.getShortCommitId());
-    //model.put("codeCommitDateTime", gitProperties.getCommitTime());
+    model.put("codeCommitDateTime", gitProperties.getCommitTime());
 
     return new ModelAndView("index", model);
   }

--- a/src/main/java/org/formflowstartertemplate/app/StaticPageController.java
+++ b/src/main/java/org/formflowstartertemplate/app/StaticPageController.java
@@ -45,5 +45,4 @@ public class StaticPageController {
   String getFaq() {
     return "faq";
   }
-
 }

--- a/src/main/java/org/formflowstartertemplate/app/StaticPageController.java
+++ b/src/main/java/org/formflowstartertemplate/app/StaticPageController.java
@@ -1,14 +1,21 @@
 package org.formflowstartertemplate.app;
 
+import java.util.HashMap;
 import javax.servlet.http.HttpSession;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.info.GitProperties;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.servlet.ModelAndView;
 
 /**
  * A controller to render static pages that are not in any flow.
  */
 @Controller
 public class StaticPageController {
+
+  @Autowired
+  GitProperties gitProperties;
 
   /**
    * Renders the website index page.
@@ -17,11 +24,16 @@ public class StaticPageController {
    * @return the static page template
    */
   @GetMapping("/")
-  String getIndex(HttpSession httpSession) {
+  ModelAndView getIndex(HttpSession httpSession) {
     // For dev, reset session if you visit home
     httpSession.invalidate();
 
-    return "index";
+    // provide a model so that we can pass the git commit hash to the footer, via the index page.
+    HashMap<String, Object> model = new HashMap<>();
+    model.put("codeCommitHashShort", gitProperties.getShortCommitId());
+    //model.put("codeCommitDateTime", gitProperties.getCommitTime());
+
+    return new ModelAndView("index", model);
   }
 
   /**
@@ -33,4 +45,5 @@ public class StaticPageController {
   String getFaq() {
     return "faq";
   }
+
 }


### PR DESCRIPTION
This adds the app's git commit hash to the index page of the app, so we can see what hash the website is running off of.  It does not display the library's git hash.  Do we want that as well?  That would have to be done slightly differently - same logic, but put into the library's code. 

It only adds the hash to the index page's footer.  Given how the controllers are split up, it might be tricky to add it to pages served by the library's controller. I suspect having it on the index page is enough, though, for when when we want this type of info. 

Relies on https://github.com/codeforamerica/form-flow/pull/25 being accepted first to display hash.