### PR TITLE
Fixes issue where DZ was still creating thumbnail for tif files.

### DIFF
--- a/src/main/resources/templates/fragments/fileUploader.html
+++ b/src/main/resources/templates/fragments/fileUploader.html
@@ -55,7 +55,6 @@
   <script src="/webjars/dropzone/5.9.3/dist/min/dropzone.min.js"></script>
   <script th:inline="javascript">
     Dropzone.autoDiscover = false;
-
     window['documentIcon'
     + [[${inputName}]]] = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEsAAABGCAYAAACE0Gk0AAAFK0lEQVR4Xu2caVcTSRSG314SyEJQPIAsMucoihDmzJE1BBhnEZ35xzPjmU9ABAR/AThnFBBQQciedLrn3Epaw6Z9OxsTqr7kQ25XVz31VtWt5baSTiYsyOSIgCJhOeIkjCQs56wkLAYrCasusFKpFF5vbmJ/7x1My4KmqZz3VmRr5A3oHh3DI6Po6e2tKC/Ow67GrJOTE7xaX8PB/gG8Xi8URYFl1XNStZDNZtF+4yamIzO42dHBqbNrWzasbDaDtZUV7GxvIxgMNgAUTUsALCCRSKCzsxMzc3Pw+wOuITh9kA3r9dYmNtZforW1FaqiflEUVaDWqUy8pGbTMpGIx3Fn4DtEorPQdb2mJWDDii0t4mB/Dx6Pt85dj8RkQRGyKiYCZhQMpJJJDN5/gPHJKahq7cZONqznf/6BZCLxuRXtAmfS6RK8WknMgq57hKLLk6KqyGbSSKfTGJuYxPBIuGbqqggWtbRlWtB0HT6fT7RqoVCAUgNeiqLCMPLIZDJFVdkKUyDeSw1Ik8zM7JzolrVIbFh/P/8L8ZMTMXWbBRPpdAq9fX2YikTR0tKCXC5X1lGqV2RN17C3t4dX6y9Fg2iq9iVzhbqkKsrl8/sQnZ1HZ1dX9V5ud3vu2vAsrFQqKVoyOjcvxpBapg8f3mM1FoNhGNC0Mlil8YuUTgN+e/sNROfnxW81U0XKskwTyWRRWSR/j8dTzbKdy+vd7i421tdQMArnYJX6JqhMx8fH6OnpxeyPj8+NcZUUsCqw+vr7EIleAVglheXzOcTjcTwYeojpmWglfE5PJpV0Q1tZVwmWGPxphsxmQDP0D4/GEB79virAmk5ZdncUM2QyiVw2i8npiFBZpak5YRV9C+FSHH/6JFyK+cc/487AQEW8mhdWGbCjw0PhB/70yxN03LrlGlhzwyqNX+TRHH78KECRwtra2lwBa3pYREXViisL6pL9dwYQmYmi1edjA7sWsGxg+XweiXgC94eG8GhsnO0XXhtYtkuRz+VAftjDkTBGwqMXO7eXaO5awRLAFEXAorXkcDjMcimuHSzbDyP/K9TejidPf3M8dv2vYO3u7mBjbRXGZWvDr1T77KYgLcYDwQAWnv3enLBo33/1xTILFjmk1PW8Xg9UVfu8u0uw2kIh/LrwtDlhHR0d4p+tLZimKdZ/ThJt5ZDb8P5gX6wVaaOSNg6bHlY5HKdHb+JgwyxgeXFRnEgFAn4Bms4em1pZTpR0kQ2paCW2jO23b8SRGTmpEtYlNMkZXYktYWd7RyrrW4qTsL5FqOx/CUvCYhBgmEplSVgMAgxTqSwJi0GAYSqVJWExCDBMpbIkLAYBhqlUloTFIMAwlcqSsBgEGKZSWRIWgwDDVCpLwmIQYJhKZUlYDAIMU6ksCYtBgGF6pZRVrwgLBp9TpgTrxfISdncaeMhKgU71jN1xC4vuRVCc5Ns3/zbu+L6eUWFuQFHgK8VwUzz12kpMKMvn89fvrkN5cGY94w1dwbIg7ozSFSUK3iwYBhSVLhwVrxwFgkEsPKvhzb/GRbK6wUXPFC+z0VVuXdNPXWarOaxGxki7xXX2OfsSblf3bREn6TSx75Q2NPreaa0usitF7ttR+xQ+PD4xibv3Bh3nyoZ1Jb7r4Lh6pw3tj3XQ9yD6+vsxFYmgpeV0gPrXsmbDoswa/8UQPi0bFMVwd3V3YWxiCqFQiJWRK1j0hkZ+i4ZVw5JxoWBCVRR03+7B3cFB+P1+djauYbHf1AQPSFiMRpSwJCwGAYbpf7oLq5uJEmkZAAAAAElFTkSuQmCC";
     window['isUploadComplete' + [[${inputName}]]] = true;
@@ -172,7 +171,7 @@
       var inputEl = document.querySelector('input[name=' + [[${inputName}]] + ']');
       inputEl.value = JSON.stringify(window['userFileIds' + [[${inputName}]]]);
     }
-    
+
     function deleteCancelledFiles(file, response) {
       let filesToDelete = window['cancelledFiles' + [[${inputName}]]];
       filesToDelete.forEach(fTD => {
@@ -184,13 +183,16 @@
           }
           showNumberOfAddedFiles();
           sendDeleteXhrRequest(file, response);
-        };
+        }
+        ;
       })
     }
-    
+
     function sendDeleteXhrRequest(file, id) {
       var xhrRequest = new XMLHttpRequest();
-      xhrRequest.open('POST', '/file-delete?' + id + '&returnPath=' + window.location.pathname + '&inputName=' + [[${inputName}]], true);
+      xhrRequest.open('POST',
+          '/file-delete?' + id + '&returnPath=' + window.location.pathname + '&inputName='
+          + [[${inputName}]], true);
       xhrRequest.withCredentials = false;
       xhrRequest.setRequestHeader("Accept", "*/*");
       xhrRequest.setRequestHeader("X-Requested-With", "XMLHttpRequest");
@@ -273,7 +275,7 @@
           if (!file.type.includes("image")) {
             setDefaultThumbnail(file);
           }
-          if (file.type.includes("image/heic")) {
+          if (file.type.includes("image/heic") || file.type.includes("image/tif")) {
             setDefaultThumbnail(file);
           }
           $('#submit-my-documents-' + [[${inputName}]]).removeClass('hidden');


### PR DESCRIPTION

https://www.pivotaltracker.com/story/show/183995116

We had missed spot where we needed to check to see if the mimetype was a tiff file.   

To test, simply upload a tif file.  See that it actually completes and displays the default icon. 
