### PR TITLE
Set thumbnail width and height to be based on variable

### DIFF
--- a/src/main/resources/templates/fragments/fileUploader.html
+++ b/src/main/resources/templates/fragments/fileUploader.html
@@ -67,7 +67,12 @@
     window['myDropZone' + [[${inputName}]]] = null;
     window['userFileIds' + [[${inputName}]]] = [];
     window['cancelledFiles' + [[${inputName}]]] = [];
-    var userFiles = [[${session.userFiles}]]
+    var userFiles = [[${session.userFiles}]];
+    // TODO: move to more global setting
+    // - either coming from fragment parameter
+    // - or from application properties
+    var thumbnailWidth = '64';
+    var thumbnailHeight = '60';
 
     function addDragBorder() {
       var dragAndDropBox = document.getElementById("drag-and-drop-box-" + [[${inputName}]]);
@@ -208,8 +213,8 @@
       previewsContainer: [[${'#document-upload-' + inputName}]] + " .preview-container",
       autoProcessQueue: false,
       thumbnailMethod: "crop",
-      thumbnailWidth: 64,
-      thumbnailHeight: 60,
+      thumbnailWidth: thumbnailWidth,
+      thumbnailHeight: thumbnailHeight,
       maxFiles: 20,
       parallelUploads: 1,
       timeout: 0,
@@ -224,7 +229,7 @@
               <div class="dz-details display-flex">
                 <div class="thumbnail">
                     <div class="dz-progress"><span class="dz-upload" data-dz-uploadprogress></span></div>
-                    <img class="dz-thumb" data-dz-thumbnail aria-hidden="true" />
+                    <img class="dz-thumb" style="width: ${thumbnailWidth}px; height: ${thumbnailHeight}px;" data-dz-thumbnail aria-hidden="true" />
                 </div>
                 <div class="file">
                     <div class="dz-filename"><div class="filename-text" data-dz-name></div></div>
@@ -410,13 +415,13 @@
         removeLink.classList.add("text--red");
 
         var filePreview = file.previewElement.getElementsByClassName("thumbnail")[0]
-        filePreview.innerHTML = "<svg class=\"margin-auto\" width=\"40\" height=\"47\" viewBox=\"0 0 40 47\" fill=\"none\" xmlns=\"http://www.w3.org/2000/svg\">\n"
+        filePreview.innerHTML = `<svg class=\"margin-auto\" style=\"width: ${thumbnailWidth}px; height: ${thumbnailHeight}px;\" width=\"40\" height=\"47\" viewBox=\"0 0 40 47\" fill=\"none\" xmlns=\"http://www.w3.org/2000/svg\">\n"
             +
             "<path d=\"M6.625 40.125H20.375L13.5 28.25L6.625 40.125ZM14.125 38.25H12.875V37H14.125V38.25ZM14.125 35.75H12.875V33.25H14.125V35.75Z\" fill=\"#D13F00\"/>\n"
             +
             "<path d=\"M26.6667 0H4.44444C3.2657 0 2.13524 0.550197 1.30175 1.52955C0.468252 2.50891 0 3.8372 0 5.22222V41.7778C0 43.1628 0.468252 44.4911 1.30175 45.4704C2.13524 46.4498 3.2657 47 4.44444 47H35.5556C36.7343 47 37.8648 46.4498 38.6983 45.4704C39.5317 44.4911 40 43.1628 40 41.7778V15.6667L26.6667 0ZM35.5556 41.7778H4.44444V5.22222H24.4444V18.2778H35.5556V41.7778Z\" fill=\"#D13F00\" fill-opacity=\"0.5\"/>\n"
             +
-            "</svg>";
+            "</svg>`;
       }
     });
   </script>


### PR DESCRIPTION
Made it so that all thumbnail images are set by the same sizing variables.

Note: there's further work to be done so that the variables are changeable by other engineers, but I figured we would do that work as a part of [default settings ticket](https://www.pivotaltracker.com/story/show/183559454).

<img width="1323" alt="Screenshot 2022-12-13 at 4 00 34 PM" src="https://user-images.githubusercontent.com/9101728/207460775-f8102913-af5c-4d67-87c1-f0bb67acb241.png">
