### PR TITLE
Updates readme with info about new `dev` profile in library

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Table of Contents
         * [Terminal](#terminal)
         * [IntelliJ](#intellij)
     * [Setup Fake Filler (optional, Chrome &amp; Firefox):](#setup-fake-filler-optional-chrome--firefox)
+    * [Spring Profile: `dev`](#spring-profile-dev)
 * [About IntelliJ Live Templates](#about-intellij-live-templates)
     * [Applying Live Templates to your IntelliJ IDE](#applying-live-templates-to-your-intellij-ide)
     * [Using Live Templates](#using-live-templates)
@@ -341,8 +342,6 @@ or `ctrl + shift + r`).
 ### Setup Fake Filler (optional, Chrome & Firefox): ###
 
 We use an automatic form filler to make manual test easier.
-
--
 
 Install [Fake Filler for Chrome](https://chrome.google.com/webstore/detail/fake-filler/bnjjngeaknajbdcgpfkgnonkmififhfo)
 or [Fake Filler for FireFox](https://addons.mozilla.org/en-US/firefox/addon/fake-filler/?utm_source=addons.mozilla.org&utm_medium=referral&utm_content=search)

--- a/README.md
+++ b/README.md
@@ -356,6 +356,15 @@ or [Fake Filler for FireFox](https://addons.mozilla.org/en-US/firefox/addon/fake
   on [Keyboard Shortcuts (chrome)](chrome-extension://bnjjngeaknajbdcgpfkgnonkmififhfo/options.html#/keyboard-shortcuts)
   to choose the shortcut you want to use to fill out the page.
 
+### Spring Profile: `dev`
+
+The Form Flow library has a `dev` Spring Profile that can be used by developers to
+get more information from the library.
+
+Please see
+[Spring Profile: `dev`](https://github.com/codeforamerica/form-flow#spring-profile-dev)
+for more information about what it provides and how to use this profile.
+
 ## About IntelliJ Live Templates ##
 
 As a team, we use [IntelliJ](https://www.jetbrains.com/idea/) and can use

--- a/src/main/java/org/formflowstartertemplate/app/StaticPageController.java
+++ b/src/main/java/org/formflowstartertemplate/app/StaticPageController.java
@@ -45,9 +45,4 @@ public class StaticPageController {
   String getFaq() {
     return "faq";
   }
-
-  @GetMapping("/icons")
-  String getIcons() {
-    return "fragments/icons";
-  }
 }


### PR DESCRIPTION
Counter part to: https://github.com/codeforamerica/form-flow/pull/84
Helps address: https://www.pivotaltracker.com/story/show/184048149

Adds README information for `dev` profile and removes the now unnecessary icons endpoint. 