### PR TITLE
WIP: Adds ability to hide a button based on dropzone feedback. 

### DIFF
--- a/src/main/resources/templates/docUpload/uploadDocuments.html
+++ b/src/main/resources/templates/docUpload/uploadDocuments.html
@@ -18,9 +18,9 @@
               <th:block
                   th:replace="fragments/fileUploader :: fileUploader(inputName=${dzFormName})"></th:block>
             </div>
-            <div class="form-card__footer">
+            <div id="submit_it" class="form-card__footer display-none">
               <th:block th:replace="fragments/inputs/submitButton :: submitButton(
-                text=#{general.inputs.continue})" />
+                text=#{general.inputs.continue})"/>
             </div>
           </th:block>
         </th:block>
@@ -29,5 +29,8 @@
   </section>
 </div>
 <th:block th:replace="fragments/footer :: footer"/>
+<script>
+  FormFlowDZ.hideContinueIfNoFiles('doc-upload-files', 'submit_it');
+</script>
 </body>
 </html>

--- a/src/main/resources/templates/docUpload/uploadDocuments.html
+++ b/src/main/resources/templates/docUpload/uploadDocuments.html
@@ -18,7 +18,7 @@
               <th:block
                   th:replace="fragments/fileUploader :: fileUploader(inputName=${dzFormName})"></th:block>
             </div>
-            <div id="submit_it" class="form-card__footer display-none">
+            <div id="submit" class="form-card__footer display-none">
               <th:block th:replace="fragments/inputs/submitButton :: submitButton(
                 text=#{general.inputs.continue})"/>
             </div>
@@ -30,7 +30,7 @@
 </div>
 <th:block th:replace="fragments/footer :: footer"/>
 <script>
-  FormFlowDZ.hideContinueIfNoFiles('doc-upload-files', 'submit_it');
+  FormFlowDZ.hideContinueIfNoFiles('doc-upload-files', 'submit');
 </script>
 </body>
 </html>

--- a/src/main/resources/templates/ubi/uploadUBIFlowDocuments.html
+++ b/src/main/resources/templates/ubi/uploadUBIFlowDocuments.html
@@ -47,7 +47,7 @@
                 </th:block>
               </div>
             </div>
-            <div class="form-card__footer">
+            <div class="form-card__footer display-none" id="submit">
               <th:block
                   th:replace="'fragments/continueButton' :: continue(text=#{adding-documents-upload-doc.im-finished-uploading})"/>
             </div>
@@ -58,5 +58,6 @@
   </section>
 </div>
 <th:block th:replace="fragments/footer :: footer"/>
+<script>FormFlowDZ.hideContinueIfNoFiles("ubiFiles", "submit")</script>
 </body>
 </html>


### PR DESCRIPTION
Based on changes in: https://github.com/codeforamerica/form-flow/pull/92
Finishes: https://www.pivotaltracker.com/story/show/182837559
Co-Authored-By: Ben Calegari; bcalegari@codeforamerica.org

This uses the new changes in the form flow library to make the "Continue" button on the file upload page only show up when there are files uploaded, not before. A SNE may choose to use this to ensure that the user uploads at least one file. 

@bencalegari  - just realizing we need to update the file upload page in the UBI flow as well, to have this behavior. 
