### PR TITLE
Add config for `uuid_function` placeholder

### DIFF
--- a/sample.env
+++ b/sample.env
@@ -1,5 +1,5 @@
 # Environment variables defined in this file will get pulled in to various places, like the
-# applications.yaml file or the grade.build file.
+# applications.yaml file or the build.gradle file.
 # This intention is that this file contain secret information (with the exception, currently, of the
 # SPRING_PROFILES_ACTIVE variable), all other configuration should go in the application.yaml file(s).
 #
@@ -19,7 +19,7 @@
 # This is used by the gradle.build file to decide which version of the form-flow library
 # to pull in.
 # Values are `dev` and unset. Leaving this unset implies we are operating in a cloud / docker
-# environment, where we will pull the form-flow library jar in it's publish version.
+# environment, where we will pull the form-flow library jar in its published version.
 # If set to `dev` we will use the locally compiled form-flow library as specified in the build.gradle file.
 SPRING_PROFILES_ACTIVE=dev
 

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -50,6 +50,9 @@ spring:
     multipart:
       max-file-size: ${form-flow.uploads.max-file-size}MB
       max-request-size: ${form-flow.uploads.max-file-size}MB
+  flyway:
+    placeholders:
+      uuid_function: "gen_random_uuid"
 management:
   endpoints:
     web:


### PR DESCRIPTION
When initializing the database, I was getting an error related to `uuid_function` being undefined, and thus the V4 migration wouldn't run.

Looking at [this commit][1], it seems that this variable can be specified in application.yaml.

Also - this fixes a couple unrelated typos in the readme.

[1]: http://github.com/codeforamerica/form-flow/commit/e2514d8a07ba5d16800ee087a142f1b12bc5bfe9