### PR TITLE
Reference form-flow-library-yaml

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -17,9 +17,9 @@ jobs:
       postgres:
         image: postgres
         env:
-          POSTGRES_USER: form-flow-test
+          POSTGRES_USER: starter-app-test
           POSTGRES_PASSWORD: postgres
-          POSTGRES_DB: form-flow-test
+          POSTGRES_DB: starter-app-test
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
         ports:
           - 5432:5432

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -13,6 +13,16 @@ jobs:
   test:
     name: Run unit tests
     runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres
+        env:
+          POSTGRES_USER: form-flow-test
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: form-flow-test
+        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+        ports:
+          - 5432:5432
     steps:
       - uses: actions/checkout@v3
       - name: Set up ChromeDriver

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -27,7 +27,7 @@ spring:
     group:
       test:
         - test
-        - form-flow-library-test
+        - form-flow-library
       dev:
         - dev
         - form-flow-library

--- a/src/test/resources/application-test.yaml
+++ b/src/test/resources/application-test.yaml
@@ -12,9 +12,14 @@ form-flow:
       auth-token: 'test-token'
 spring:
   datasource:
-    url: jdbc:h2:mem:testdb;MODE=PostgreSQL;DB_CLOSE_DELAY=-1;
-    username: sa
-    password: sa
+    url: jdbc:postgresql://localhost:5432/form-flow-test
+    username: form-flow-test
+    password: postgres
+  flyway:
+    baselineOnMigrate: true
+    clean-on-validation-error: true
+    placeholders:
+      uuid_function: "gen_random_uuid"
   thymeleaf:
     prefix: classpath:/templates/
   jpa:

--- a/src/test/resources/application-test.yaml
+++ b/src/test/resources/application-test.yaml
@@ -12,8 +12,8 @@ form-flow:
       auth-token: 'test-token'
 spring:
   datasource:
-    url: jdbc:postgresql://localhost:5432/form-flow-test
-    username: form-flow-test
+    url: jdbc:postgresql://localhost:5432/starter-app-test
+    username: starter-app-test
     password: postgres
   flyway:
     baselineOnMigrate: true


### PR DESCRIPTION
- Consumers now need to use form-flow-library for test rather than form-flow-library test.. should be the only change they'll need to make!

[#184056302]