### PR TITLE
Updates income related radio mappings

### DIFF
--- a/src/main/java/org/formflowstartertemplate/app/pdf/ApplicantIncomePreparer.java
+++ b/src/main/java/org/formflowstartertemplate/app/pdf/ApplicantIncomePreparer.java
@@ -18,6 +18,16 @@ public class ApplicantIncomePreparer implements SubmissionFieldPreparer {
   @Override
   public Map<String, SubmissionField> prepareSubmissionFields(Submission submission, Map<String, Object> data, PdfMap pdfMap) {
     Map<String, SubmissionField> applicantIncomeFieldMap = new HashMap<>();
+    
+    boolean applicantReportedTotalHouseholdIncome = submission.getInputData().containsKey("reportedTotalAnnualHouseholdIncome");
+    
+    if (applicantReportedTotalHouseholdIncome) {
+      if (submission.getInputData().get("reportedTotalAnnualHouseholdIncome").equals("0")) {
+        applicantIncomeFieldMap.put("applicantReceivesIncome", new SingleField("applicantReceivesIncome", "No", null));
+      } else {
+        applicantIncomeFieldMap.put("applicantReceivesIncome", new SingleField("applicantReceivesIncome", "Yes", null));
+      }
+    }
 
     boolean householdHasIncome = submission.getInputData().containsKey("income");
 
@@ -25,10 +35,10 @@ public class ApplicantIncomePreparer implements SubmissionFieldPreparer {
       ArrayList<Map<String, Object>> householdIncomeSubflow = (ArrayList<Map<String, Object>>) submission.getInputData()
           .get("income");
 
-      boolean applicantHasIncome = householdIncomeSubflow.stream()
+      boolean applicantEnteredIncomeAmounts = householdIncomeSubflow.stream()
           .anyMatch(iteration -> iteration.get("householdMember").equals("applicant"));
 
-      if (applicantHasIncome) {
+      if (applicantEnteredIncomeAmounts) {
         applicantIncomeFieldMap.put("applicantReceivesIncome", new SingleField("applicantReceivesIncome", "Yes", null));
 
         Map<String, Object> applicantSubflowIteration = householdIncomeSubflow.stream().filter(iteration ->

--- a/src/main/java/org/formflowstartertemplate/app/pdf/HouseholdMemberReceivesIncomePreparer.java
+++ b/src/main/java/org/formflowstartertemplate/app/pdf/HouseholdMemberReceivesIncomePreparer.java
@@ -17,15 +17,19 @@ public class HouseholdMemberReceivesIncomePreparer implements SubmissionFieldPre
     Map<String, SubmissionField> householdMembersReceivingIncomeMap = new HashMap<>();
     int maxIterations = pdfMap.getSubflowInfo().get("householdAndIncome").getTotalIterations();
     
-    for (int index = 1; index <= maxIterations; index++) {
-      if (data.containsKey("incomeTypes_" + index + "[]")) {
-        householdMembersReceivingIncomeMap.put(
-            "householdMemberReceivesIncome_" + index,
-            new SingleField("householdMemberReceivesIncome_" + index, "Yes", null));
-      } else {
-        householdMembersReceivingIncomeMap.put(
-            "householdMemberReceivesIncome_" + index,
-            new SingleField("householdMemberReceivesIncome_" + index, "No", null));
+    boolean householdHasIncome = submission.getInputData().containsKey("income");
+    
+    if (householdHasIncome) {
+      for (int index = 1; index <= maxIterations; index++) {
+        if (data.containsKey("incomeTypes_" + index + "[]")) {
+          householdMembersReceivingIncomeMap.put(
+              "householdMemberReceivesIncome_" + index,
+              new SingleField("householdMemberReceivesIncome_" + index, "Yes", null));
+        } else {
+          householdMembersReceivingIncomeMap.put(
+              "householdMemberReceivesIncome_" + index,
+              new SingleField("householdMemberReceivesIncome_" + index, "No", null));
+        }
       }
     }
     


### PR DESCRIPTION
This PR fixes two issues I noticed with income related mappings for PDF generation.

1. We provide the applicant with an alternative to entering all forms of income for themselves and their household, instead opting to just enter a single income amount for their entire household. If the applicant chooses to enter income in this way, we will now select yes for the "Do you receive income" radio for the applicant on the PDF. If they select to enter income in this way, but enter 0 as the amount, we will select No for the radio.

2. We will now no longer select No on the radio for individual household members having income if there is no income subflow. 