### PR TITLE
Automatically bump form-flow snapshot when new version is released

### DIFF
--- a/.github/workflows/bump-snapshot.yaml
+++ b/.github/workflows/bump-snapshot.yaml
@@ -1,0 +1,30 @@
+name: Bump form-flow snapshot
+on:
+  repository_dispatch:
+    types: [ form-flow-snapshot-bumped ]
+jobs:
+  bump_snapshot:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: main
+          token: ${{ secrets.PLATFORM_ROBOT_PAT }}
+      - name: Update snapshot version
+        run: sed -i 's/formFlowLibraryVersion =.*/formFlowLibraryVersion = "{{ github.event.client_payload.version }}"/' build.gradle
+  run_tests:
+    name: Run tests
+    needs: bump-snapshot
+    uses: ./.github/workflows/run-tests.yml
+  push_snapshot_update_changes:
+    needs: run-tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Push snapshot update changes
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_user_name: cfa-platforms-robot
+          commit_message: Bump version to ${{github.event.client_payload.version}}
+          commit_user_email: platforms-robot@codeforamerica.org
+          commit_author: CfA Platforms Robot <platforms-robot@codeforamerica.org>
+          push_options: --force

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -5,7 +5,8 @@ on:
     branches: [ main ]
   pull_request:
   repository_dispatch:
-    types: [form-flow-published]
+    types: [form-flow-snapshot-updated]
+  workflow_call:
 
 env:
   USERNAME: ${{ secrets.GPR_USER }}


### PR DESCRIPTION
- Changed repository_dispatch event for run-test to clarify the difference in events

[#185136763]