### PR TITLE
Do not merge! Adds thymeleaf dependency to potentially fix ontology issue in intellij

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,7 @@ def useLocalLibrary = System.getenv('USE_LOCAL_LIBRARY')
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 
     if (profile == 'dev' || useLocalLibrary == 'true') {
         implementation fileTree(dir: "$rootDir/../form-flow/build/libs", include: '*.jar')


### PR DESCRIPTION
This seams to fix the issue where intellij complains about the thymeleaf prefixes, like `th:ref`, `th:block`, etc.   

Including that must include the ontology definition.

Do we want to add this in to stop those warnings?  