### PR TITLE
Use the profile specified in the enviroment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,4 +10,4 @@ RUN ./gradlew assemble && \
 
 EXPOSE 8080
 
-ENTRYPOINT ["java", "-jar", "/opt/form-flow-starter-app/app.jar", "--spring.profiles.active=demo"]
+ENTRYPOINT ["java", "-jar", "/opt/form-flow-starter-app/app.jar"]


### PR DESCRIPTION
Co-authored-by: Chibuisi Enyia<cenyia@codeforamerica.org>

Aptible deploy sets the profile using the envvar
`SPRING_PROFILES_ACTIVE`. We should use that instead of overriding it in the Dockerfile.